### PR TITLE
Use a dispatch_once to speed up colour generation, add a gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Xcode
+.DS_Store
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+*.xcworkspace
+!default.xcworkspace
+xcuserdata
+profile
+*.moved-aside
+DerivedData
+.idea/

--- a/JFMinimalNotification/UIColor+JFMinimalNotificationColors.m
+++ b/JFMinimalNotification/UIColor+JFMinimalNotificationColors.m
@@ -29,37 +29,86 @@
 
 + (instancetype)notificationGreenColor
 {
-    return hsb(145, 77, 80);
+    static UIColor *green = nil;
+    static dispatch_once_t dispatchToken;
+    
+    dispatch_once(&dispatchToken, ^{
+        green = hsb(145, 77, 80);
+    });
+    
+    return green;
 }
 
 + (instancetype)notificationRedColor
 {
-    return hsb(6, 74, 91);
+    static UIColor *red = nil;
+    static dispatch_once_t dispatchToken;
+    
+    dispatch_once(&dispatchToken, ^{
+        red = hsb(6, 74, 91);
+    });
+    
+    return red;
 }
 
 + (instancetype)notificationYellowColor
 {
-    return hsb(48, 83, 100);
+    static UIColor *yellow = nil;
+    static dispatch_once_t dispatchToken;
+    
+    dispatch_once(&dispatchToken, ^{
+        yellow = hsb(48, 83, 100);
+    });
+    
+    return yellow;
 }
 
 + (instancetype)notificationBlueColor
 {
-    return hsb(224, 50, 63);
+    static UIColor *blue = nil;
+    static dispatch_once_t dispatchToken;
+    
+    dispatch_once(&dispatchToken, ^{
+        blue = hsb(224, 50, 63);
+    });
+    
+    return blue;
 }
 
 + (instancetype)notificationBlackColor
 {
-    return hsb(0, 0, 17);
+    static UIColor *black = nil;
+    static dispatch_once_t dispatchToken;
+    
+    dispatch_once(&dispatchToken, ^{
+        black = hsb(0, 0, 17);
+    });
+    
+    return black;
 }
 
 + (instancetype)notificationWhiteColor
 {
-    return hsb(192, 2, 95);
+    static UIColor *white = nil;
+    static dispatch_once_t dispatchToken;
+    
+    dispatch_once(&dispatchToken, ^{
+        white = hsb(192, 2, 95);
+    });
+    
+    return white;
 }
 
 + (instancetype)notificationOrangeColor
 {
-    return hsb(28, 85, 90);
+    static UIColor *orange = nil;
+    static dispatch_once_t dispatchToken;
+    
+    dispatch_once(&dispatchToken, ^{
+        orange = hsb(28, 85, 90);
+    });
+    
+    return orange;
 }
 
 @end


### PR DESCRIPTION
The dispatch_once is used to circumvent the expensive colour generation for the 2nd-nth time generation colours. I was seeing performance improvements of 8-12x on an iPhone 6.

Adds a fairly standard gitignore file for the example project too.