### PR TITLE
Added feature to put padding on top or bottom of a notification so it can show above a UINavigationBar/UIToolbar

### DIFF
--- a/JFMinimalNotification/JFMinimalNotification.h
+++ b/JFMinimalNotification/JFMinimalNotification.h
@@ -75,9 +75,15 @@ typedef void (^JFMinimalNotificationTouchHandler)(void);
 @property (nonatomic, assign) BOOL presentFromTop;
 
 /**
+ * @return The current padding from the bottom/top of the screen (depending on if presentFrom Top is set or not)
+ */
+@property (nonatomic, assign) CGFloat edgePadding;
+  
+/**
  * @return The JFMinimalNotificationDelegate
  */
 @property (nonatomic, weak) id<JFMinimalNotificationDelegate> delegate;
+
 
 
 #pragma mark ----------------------
@@ -168,6 +174,12 @@ typedef void (^JFMinimalNotificationTouchHandler)(void);
  * @param view The desired UIView to be set as the right view
  */
 - (void)setRightAccessoryView:(UIView*)view animated:(BOOL)animated;
+
+/**
+ * @return Sets the edge padding
+ * @param edgePadding The desired edgePadding
+ */
+-(void)setEdgePadding:(CGFloat)edgePadding;
 
 @end
 

--- a/JFMinimalNotification/JFMinimalNotification.m
+++ b/JFMinimalNotification/JFMinimalNotification.m
@@ -86,6 +86,7 @@ static CGFloat const kNotificationAccessoryPadding = 10.0f;
     _subTitleLabelHorizontalConsraints  = nil;
     _subTitleLabelVerticalConsraints    = nil;
     _dismissalTimer                     = nil;
+    _edgePadding                        = 0;
 }
 
 + (instancetype)notificationWithStyle:(JFMinimalNotificationStyle)style title:(NSString*)title subTitle:(NSString*)subTitle
@@ -139,6 +140,7 @@ static CGFloat const kNotificationAccessoryPadding = 10.0f;
         
         [self setTitle:title withSubTitle:subTitle];
         [self setStyle:style animated:NO];
+        [self setEdgePadding:0];
         
     }
     return self;
@@ -175,13 +177,13 @@ static CGFloat const kNotificationAccessoryPadding = 10.0f;
         UIView* superview = self.superview;
         UIView* notification = self;
         NSDictionary* views = NSDictionaryOfVariableBindings(superview, notification);
-        NSDictionary* metrics = @{@"height": @(kNotificationViewHeight)};
+        NSDictionary* metrics = @{@"height": @(kNotificationViewHeight), @"edgepadding": @(_edgePadding)};
         
         NSString* verticalConstraintString;
         if (self.presentFromTop) {
-            verticalConstraintString = @"V:|[notification(==height)]";
+            verticalConstraintString = @"V:|-edgepadding-[notification(==height)]";
         } else {
-            verticalConstraintString = @"V:[notification(==height)]|";
+            verticalConstraintString = @"V:[notification(==height)]-edgepadding-|";
         }
         
         self.notificationVerticalConstraints = [NSLayoutConstraint constraintsWithVisualFormat:verticalConstraintString options:0 metrics:metrics views:views];
@@ -661,6 +663,13 @@ static CGFloat const kNotificationAccessoryPadding = 10.0f;
             }];
         }
     }
+}
+
+-(void)setEdgePadding:(CGFloat)ePadding
+{
+  if(ePadding >= 0) {
+    _edgePadding = ePadding;
+  }
 }
 
 #pragma mark ----------------------


### PR DESCRIPTION
Added an edgePadding property that controls how much padding is between the bottom/top of the notification and the corresponding edge on the view.