### PR TITLE
Add Modulemap so JSMinimalNotifications may be easily used from Swift

### DIFF
--- a/JFMinimalNotification/JSMinimalNotifications.modulemap
+++ b/JFMinimalNotification/JSMinimalNotifications.modulemap
@@ -1,0 +1,9 @@
+framework module JSMinimalNotifications {
+    header "JSMinimalNotification.h"
+    header "JSMinimalNotificationArt.h"
+    header "NSInvocation+Constructors.h"
+    header "UIColor+JFMinimalNotificationColors"
+    header "UIView+Round"
+
+    export *
+}

--- a/JFMinimalNotifications.podspec
+++ b/JFMinimalNotifications.podspec
@@ -88,7 +88,7 @@ Pod::Spec.new do |s|
   s.source_files  = "JFMinimalNotification/*.{h,m}"
   # s.exclude_files = "Classes/Exclude"
   s.public_header_files = "JFMinimalNotification/*.h"
-
+  s.module_map = "JFMinimalNotification/JSMinimalNotifications.modulemap"
 
   # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   #


### PR DESCRIPTION
Hey,

I wanted to use your notifications, but ran into a hiccup importing them into Swift. Here's a quick fix to add a modulemap. 