### PR TITLE
Remove cast of pointer to BOOL. 

### DIFF
--- a/JFMinimalNotification/JFMinimalNotification.m
+++ b/JFMinimalNotification/JFMinimalNotification.m
@@ -167,7 +167,7 @@ static CGFloat const kNotificationAccessoryPadding = 10.0f;
 
 - (BOOL)isReadyToDisplay
 {
-    return (BOOL)self.superview;
+    return self.superview ? YES : NO;
 }
 
 - (void)show


### PR DESCRIPTION
Can cause false results if the 8 least significant bits are all zero.
This in turn manifests itself in an assert when calling show on the notification.