### PR TITLE
Fixes iOS 10 display animation issue

### DIFF
--- a/JFMinimalNotification/JFMinimalNotification.m
+++ b/JFMinimalNotification/JFMinimalNotification.m
@@ -291,7 +291,7 @@ static CGFloat const kNotificationAccessoryPadding = 10.0f;
     [self.superview addConstraints:self.notificationHorizontalConstraints];
     
     if (layoutIfNeeded) {
-        [self layoutIfNeeded];
+        [self.superview layoutIfNeeded];
     }
 }
 


### PR DESCRIPTION
The initial position of the animation is incorrect on iOS 10, because `layoutIfNeeded` has to be called on the `superview`.

This fix is similar to what has been done in https://github.com/atljeremy/JFMinimalNotifications/commit/8fb811c48e9f35308750ebdba5129b220deddf10, but preparing the view layout correctly was missing.

An hotfix release on cocoapods (after merging this) would be much appreciated :)